### PR TITLE
Introduce optional Node.js backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vercel
+node_modules/
+data/responses.json

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Dette prosjektet er en web-applikasjon designet for å hjelpe bedrifter med å e
 3.  **Ingen server nødvendig for grunnleggende funksjonalitet:** Siden applikasjonen bruker `fetch` for å laste lokale JSON-filer, kan det hende at noen nettlesere har sikkerhetsrestriksjoner (CORS policy) som forhindrer dette når man åpner `index.html` direkte fra filsystemet (`file:///`).
     *   **Anbefalt løsning for utvikling:** Bruk en enkel lokal webserver. Mange kodeeditorer (som VS Code med "Live Server"-utvidelsen) har innebygd funksjonalitet for dette. Alternativt kan du bruke Python's `http.server` (Python 3: `python -m http.server`) eller Node.js-baserte servere som `http-server`.
     *   Start serveren i rotmappen til prosjektet og åpne den oppgitte adressen (f.eks. `http://localhost:8000`) i nettleseren.
+4.  **Valgfri Node-backend:** Kjør `node server.js` for å starte en enkel server som også lagrer innsendte resultater og serverer JSON-data på `/api/*` endepunkter.
 
 ## Fremtidig Utvikling (Fase 3 og utover)
 

--- a/server.js
+++ b/server.js
@@ -1,0 +1,99 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const url = require('url');
+
+const PORT = process.env.PORT || 3000;
+const dataDir = path.join(__dirname, 'data');
+const responsesFile = path.join(dataDir, 'responses.json');
+
+if (!fs.existsSync(dataDir)) {
+  fs.mkdirSync(dataDir);
+}
+if (!fs.existsSync(responsesFile)) {
+  fs.writeFileSync(responsesFile, '[]');
+}
+
+function sendJSON(res, filePath) {
+  fs.readFile(filePath, 'utf8', (err, data) => {
+    if (err) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Failed to read file' }));
+    } else {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(data);
+    }
+  });
+}
+
+function saveResponse(body, res) {
+  fs.readFile(responsesFile, 'utf8', (err, data) => {
+    let arr = [];
+    if (!err) {
+      try { arr = JSON.parse(data); } catch (e) {}
+    }
+    arr.push(body);
+    fs.writeFile(responsesFile, JSON.stringify(arr, null, 2), err2 => {
+      if (err2) {
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Could not save response' }));
+      } else {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: 'saved' }));
+      }
+    });
+  });
+}
+
+function serveStatic(res, pathname) {
+  let filePath = path.join(__dirname, pathname);
+  if (pathname === '/' || pathname === '') {
+    filePath = path.join(__dirname, 'index2.html');
+  }
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+    } else {
+      const ext = path.extname(filePath).toLowerCase();
+      const mimeTypes = { '.js': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.html': 'text/html' };
+      const mime = mimeTypes[ext] || 'application/octet-stream';
+      res.writeHead(200, { 'Content-Type': mime });
+      res.end(data);
+    }
+  });
+}
+
+const server = http.createServer((req, res) => {
+  const parsedUrl = url.parse(req.url, true);
+  if (req.method === 'GET') {
+    switch (parsedUrl.pathname) {
+      case '/api/questions':
+        return sendJSON(res, path.join(__dirname, 'questions_no.json'));
+      case '/api/levels':
+        return sendJSON(res, path.join(__dirname, 'levels_no.json'));
+      case '/api/config':
+        return sendJSON(res, path.join(__dirname, 'config_no.json'));
+      default:
+        return serveStatic(res, parsedUrl.pathname);
+    }
+  } else if (req.method === 'POST' && parsedUrl.pathname === '/api/responses') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      try {
+        const data = JSON.parse(body || '{}');
+        saveResponse(data, res);
+      } catch (e) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Invalid JSON' }));
+      }
+    });
+  } else {
+    serveStatic(res, parsedUrl.pathname);
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add a simple Node server to serve JSON and store responses
- fetch data from `/api` endpoints with fallback to local files
- send completed results to the backend
- document how to run the Node server
- ignore node_modules and stored responses

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_684027b399c08328ac447c0d73b95550