### PR TITLE
Fix static file path traversal

### DIFF
--- a/server.js
+++ b/server.js
@@ -45,11 +45,20 @@ function saveResponse(body, res) {
   });
 }
 
+const staticBasePath = path.resolve(__dirname);
+
 function serveStatic(res, pathname) {
-  let filePath = path.join(__dirname, pathname);
   if (pathname === '/' || pathname === '') {
-    filePath = path.join(__dirname, 'index2.html');
+    pathname = '/index2.html';
   }
+
+  const filePath = path.resolve(path.join(staticBasePath, pathname));
+  if (!filePath.startsWith(staticBasePath)) {
+    res.writeHead(400);
+    res.end('Invalid path');
+    return;
+  }
+
   fs.readFile(filePath, (err, data) => {
     if (err) {
       res.writeHead(404);


### PR DESCRIPTION
## Summary
- tighten static file handling in `server.js` by resolving the requested path and rejecting path traversal attempts

## Testing
- `node server.js` *(launched server to verify it starts successfully)*

------
https://chatgpt.com/codex/tasks/task_b_6844a896a3e08322849356ed05d1d2b8