### PR TITLE
Handle OR logic correctly

### DIFF
--- a/script.js
+++ b/script.js
@@ -274,62 +274,71 @@
         }
         return avgScores;
     }
+
     function evaluateMaturityProfileCondition(conditionLogic, categoryScores) {
+        const parseToken = (token) => {
+            const parts = token.split('_');
+            const potentialOp = parts[parts.length - 1];
+            if (potentialOp === 'min' || potentialOp === 'max') {
+                parts.pop();
+                return { category: parts.join('_'), operator: potentialOp };
+            }
+            return { category: token, operator: null };
+        };
         let allConditionsMet = true;
         for (const key in conditionLogic) {
-            const parts = key.split('_');
-            let category = parts[0];
-            const operator = parts.length > 1 ? parts[parts.length -1] : null;
             const threshold = conditionLogic[key];
-
-            if (category === "balancedProfile") {
+    
+            if (key.includes('_OR_')) {
+                const [token1, token2] = key.split('_OR_');
+                const first = parseToken(token1);
+                const second = parseToken(token2);
+                const score1 = first.category in categoryScores ? categoryScores[first.category] : 0;
+                const score2 = second.category in categoryScores ? categoryScores[second.category] : 0;
+                const check = (score, op) => {
+                    switch (op) {
+                        case 'min': return score >= threshold;
+                        case 'max': return score <= threshold;
+                        default: return score === threshold;
+                    }
+                };
+                if (!(check(score1, first.operator) || check(score2, second.operator))) {
+                    allConditionsMet = false;
+                    break;
+                }
+                continue;
+            }
+    
+            const { category, operator } = parseToken(key);
+            if (category === 'balancedProfile') {
                 const rawAvgScores = getCategoryScores(false);
                 const rawScoresArray = Object.values(rawAvgScores).filter(s => typeof s === 'number');
                 if (rawScoresArray.length < Object.keys(rawAvgScores).length) {
                     allConditionsMet = false; break;
                 }
-                if (!(Math.min(...rawScoresArray) >= conditionLogic.balancedProfile_min && 
+                if (!(Math.min(...rawScoresArray) >= conditionLogic.balancedProfile_min &&
                       (Math.max(...rawScoresArray) - Math.min(...rawScoresArray)) <= conditionLogic.balancedProfile_maxDiff)) {
                     allConditionsMet = false; break;
                 }
                 continue;
             }
-            
-            if(key.includes("_OR_")){
-                const or_parts = category.split("_OR_");
-                const cat1 = or_parts[0];
-                const cat2 = or_parts[1];
-                 // Ensure categoryScores has the properties before accessing
-                const score1 = categoryScores.hasOwnProperty(cat1) ? categoryScores[cat1] : 0;
-                const score2 = categoryScores.hasOwnProperty(cat2) ? categoryScores[cat2] : 0;
-
-                if(!( score1 >= threshold || score2 >= threshold) ){
-                    allConditionsMet = false; break;
-                }
-                continue;
-            }
-
-            if (!categoryScores.hasOwnProperty(category)) {
-                allConditionsMet = false; break;
-            }
-
+    
+            if (!categoryScores.hasOwnProperty(category)) { allConditionsMet = false; break; }
             const scoreToCheck = categoryScores[category] || 0;
-
             switch (operator) {
-                case "min":
+                case 'min':
                     if (!(scoreToCheck >= threshold)) { allConditionsMet = false; }
                     break;
-                case "max":
+                case 'max':
                     if (!(scoreToCheck <= threshold)) { allConditionsMet = false; }
                     break;
-                default: 
+                default:
                     if (scoreToCheck !== threshold) { allConditionsMet = false; }
             }
             if (!allConditionsMet) break;
         }
         return allConditionsMet;
     }
-
 
     function showResult() {
         calculateOverallScores(); 
@@ -629,5 +638,8 @@
         }
     });
     if(startButton) startButton.disabled = true;
+    if (typeof module !== "undefined" && module.exports) {
+        module.exports.evaluateMaturityProfileCondition = evaluateMaturityProfileCondition;
+    }
 
 })();

--- a/test/orLogic.test.js
+++ b/test/orLogic.test.js
@@ -1,0 +1,37 @@
+const assert = require('assert');
+
+// Minimal DOM stubs so script.js can load in Node
+function elementStub() {
+  return {
+    addEventListener: () => {},
+    querySelector: () => elementStub(),
+    appendChild: () => {},
+    setAttribute: () => {},
+    style: {},
+    hidden: false,
+    textContent: ''
+  };
+}
+
+global.document = {
+  getElementById: () => elementStub(),
+  querySelector: () => elementStub(),
+  addEventListener: () => {}
+};
+
+global.window = {}; // some scripts may check for window
+
+const { evaluateMaturityProfileCondition } = require('../script.js');
+
+const logic = { 'Datainnsamling_min_OR_Dataanalyse_min': 3.5 };
+
+let scores = { Datainnsamling: 3.6, Dataanalyse: 2.0 };
+assert.strictEqual(evaluateMaturityProfileCondition(logic, scores), true, 'Should match when first category qualifies');
+
+scores = { Datainnsamling: 2.0, Dataanalyse: 3.6 };
+assert.strictEqual(evaluateMaturityProfileCondition(logic, scores), true, 'Should match when second category qualifies');
+
+scores = { Datainnsamling: 2.0, Dataanalyse: 3.0 };
+assert.strictEqual(evaluateMaturityProfileCondition(logic, scores), false, 'Should fail when neither qualifies');
+
+console.log('All OR logic tests passed');


### PR DESCRIPTION
## Summary
- improve `evaluateMaturityProfileCondition` to parse keys containing `_OR_`
- export the function for Node usage
- add Node-based unit tests for OR condition handling

## Testing
- `node test/orLogic.test.js`

------
https://chatgpt.com/codex/tasks/task_b_6844aa4118048322b26bccb1d7971e12