### PR TITLE
Add server tests

### DIFF
--- a/server.js
+++ b/server.js
@@ -97,3 +97,5 @@ const server = http.createServer((req, res) => {
 server.listen(PORT, () => {
   console.log(`Server running at http://localhost:${PORT}`);
 });
+
+module.exports = server;

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,36 @@
+const { before, after, test } = require('node:test');
+const assert = require('node:assert');
+const { once } = require('node:events');
+
+let server;
+let port;
+
+before(async () => {
+  process.env.PORT = 0;
+  server = require('../server');
+  await once(server, 'listening');
+  port = server.address().port;
+});
+
+after(async () => {
+  server.close();
+});
+
+async function fetchJSON(endpoint) {
+  const res = await fetch(`http://localhost:${port}${endpoint}`);
+  assert.strictEqual(res.status, 200);
+  const data = await res.json();
+  assert.ok(data);
+}
+
+test('GET /api/config returns JSON', async () => {
+  await fetchJSON('/api/config');
+});
+
+test('GET /api/questions returns JSON', async () => {
+  await fetchJSON('/api/questions');
+});
+
+test('GET /api/levels returns JSON', async () => {
+  await fetchJSON('/api/levels');
+});


### PR DESCRIPTION
## Summary
- export the server instance for programmatic use
- add a Node `tests/` directory with requests against `/api/config`, `/api/questions`, and `/api/levels`

## Testing
- `node tests/server.test.js`

------
https://chatgpt.com/codex/tasks/task_b_6844aa23c65c8322aaf156f654f2a4c1