### PR TITLE
Improve option accessibility

### DIFF
--- a/script.js
+++ b/script.js
@@ -125,7 +125,8 @@
         const optionsDiv = document.createElement('div');
         optionsDiv.classList.add('options');
         questionData.options.forEach((option, i) => {
-            const optionElement = document.createElement('div');
+            const optionElement = document.createElement('button');
+            optionElement.type = 'button';
             optionElement.classList.add('option');
             const optionContent = document.createElement('div');
             optionContent.classList.add('option-content');

--- a/style.css
+++ b/style.css
@@ -64,10 +64,19 @@
             padding: 12px 15px;
             cursor: pointer;
             transition: all 0.2s ease;
+            display: block;
+            width: 100%;
+            text-align: left;
+            font: inherit;
+            color: var(--text-color-medium);
         }
         .option:hover {
             background-color: var(--border-color-medium);
             transform: translateY(-2px);
+        }
+        .option:focus {
+            outline: 2px solid var(--primary-color);
+            outline-offset: 2px;
         }
         .selected {
             background-color: #dbeafe;


### PR DESCRIPTION
## Summary
- render each answer option as a `<button>` instead of a `<div>`
- adjust option styles so the new buttons look like before

## Testing
- `node tests/server.test.js`
- `node test/orLogic.test.js`


------
https://chatgpt.com/codex/tasks/task_b_6844b1fe0b688322bb4967cb582b4f23