### PR TITLE
Cache JSON files in memory

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,6 +7,54 @@ const PORT = process.env.PORT || 3000;
 const dataDir = path.join(__dirname, 'data');
 const responsesFile = path.join(dataDir, 'responses.json');
 
+// Paths to JSON resources that should be cached
+const dataFiles = {
+  questions: path.join(__dirname, 'questions_no.json'),
+  levels: path.join(__dirname, 'levels_no.json'),
+  config: path.join(__dirname, 'config_no.json')
+};
+
+// In-memory cache for the JSON files
+const cachedData = {};
+const watchers = [];
+
+function loadCache() {
+  for (const [key, file] of Object.entries(dataFiles)) {
+    try {
+      cachedData[key] = fs.readFileSync(file, 'utf8');
+    } catch (err) {
+      console.error(`Failed to load ${file}:`, err);
+      cachedData[key] = 'null';
+    }
+  }
+}
+
+function watchForChanges() {
+  for (const [key, file] of Object.entries(dataFiles)) {
+    const handler = (curr, prev) => {
+      if (curr.mtimeMs !== prev.mtimeMs) {
+        try {
+          cachedData[key] = fs.readFileSync(file, 'utf8');
+          console.log(`${file} updated. Cache refreshed.`);
+        } catch (err) {
+          console.error(`Failed to reload ${file}:`, err);
+        }
+      }
+    };
+    fs.watchFile(file, handler);
+    watchers.push({ file, handler });
+  }
+}
+
+function unwatchFiles() {
+  for (const { file, handler } of watchers) {
+    fs.unwatchFile(file, handler);
+  }
+}
+
+loadCache();
+watchForChanges();
+
 if (!fs.existsSync(dataDir)) {
   fs.mkdirSync(dataDir);
 }
@@ -14,16 +62,15 @@ if (!fs.existsSync(responsesFile)) {
   fs.writeFileSync(responsesFile, '[]');
 }
 
-function sendJSON(res, filePath) {
-  fs.readFile(filePath, 'utf8', (err, data) => {
-    if (err) {
-      res.writeHead(500, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ error: 'Failed to read file' }));
-    } else {
-      res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(data);
-    }
-  });
+function sendCachedJSON(res, key) {
+  const data = cachedData[key];
+  if (data === undefined) {
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not found' }));
+    return;
+  }
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(data);
 }
 
 function saveResponse(body, res) {
@@ -78,11 +125,11 @@ const server = http.createServer((req, res) => {
   if (req.method === 'GET') {
     switch (parsedUrl.pathname) {
       case '/api/questions':
-        return sendJSON(res, path.join(__dirname, 'questions_no.json'));
+        return sendCachedJSON(res, 'questions');
       case '/api/levels':
-        return sendJSON(res, path.join(__dirname, 'levels_no.json'));
+        return sendCachedJSON(res, 'levels');
       case '/api/config':
-        return sendJSON(res, path.join(__dirname, 'config_no.json'));
+        return sendCachedJSON(res, 'config');
       default:
         return serveStatic(res, parsedUrl.pathname);
     }
@@ -105,6 +152,10 @@ const server = http.createServer((req, res) => {
 
 server.listen(PORT, () => {
   console.log(`Server running at http://localhost:${PORT}`);
+});
+
+server.on('close', () => {
+  unwatchFiles();
 });
 
 module.exports = server;


### PR DESCRIPTION
## Summary
- cache config, levels, and questions JSON files when the server starts
- watch the JSON files for changes and refresh the cache
- return cached JSON data for API endpoints

## Testing
- `node --test tests/server.test.js`

------
https://chatgpt.com/codex/tasks/task_b_6844b1fe5d708322af6bf1a439b4192c