### PR TITLE
Add OG image endpoint

### DIFF
--- a/docs/og-image-generation.md
+++ b/docs/og-image-generation.md
@@ -56,3 +56,14 @@ Reference the function from your `<head>` tags:
 ```
 
 The URL parameters allow you to adjust the text or other values dynamically.
+
+## Local Node server
+
+This repository's `server.js` exposes the same functionality for local testing.
+After running `npm start`, visit:
+
+```
+http://localhost:3000/api/og?title=Hello
+```
+
+The server will return a PNG image containing the provided title.

--- a/index2.html
+++ b/index2.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta property="og:image" content="/api/og?title=Selvevaluering" />
     <title>Selvevaluering - Digital Modenhet</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <!-- Link til den eksterne CSS-filen -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "digital-modenhet",
       "version": "1.0.0",
       "dependencies": {
-        "@vercel/og": "^0.6.8"
+        "@vercel/og": "^0.6.8",
+        "react": "^18.2.0"
       }
     },
     "node_modules/@resvg/resvg-wasm": {
@@ -145,6 +146,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
     "node_modules/linebreak": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
@@ -153,6 +160,18 @@
       "dependencies": {
         "base64-js": "0.0.8",
         "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/pako": {
@@ -176,6 +195,18 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/satori": {
       "version": "0.12.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "node tests/server.test.js && node test/orLogic.test.js"
   },
   "dependencies": {
-    "@vercel/og": "^0.6.8"
+    "@vercel/og": "^0.6.8",
+    "react": "^18.2.0"
   }
 }

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -34,3 +34,11 @@ test('GET /api/questions returns JSON', async () => {
 test('GET /api/levels returns JSON', async () => {
   await fetchJSON('/api/levels');
 });
+
+test('GET /api/og returns an image', async () => {
+  const res = await fetch(`http://localhost:${port}/api/og?title=test`);
+  assert.strictEqual(res.status, 200);
+  assert.strictEqual(res.headers.get('content-type'), 'image/png');
+  const buf = await res.arrayBuffer();
+  assert.ok(buf.byteLength > 0);
+});


### PR DESCRIPTION
## Summary
- add `react` dependency
- expose `/api/og` endpoint using `@vercel/og`
- document local OG endpoint
- add meta tag referencing the endpoint
- test new route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6845673e617c83229d5cbc531c87f419