### PR TITLE
Fix: Convert api/og.js to CommonJS syntax

### DIFF
--- a/api/og.js
+++ b/api/og.js
@@ -1,10 +1,10 @@
-import { ImageResponse } from '@vercel/og';
+const { ImageResponse } = require('@vercel/og');
 
-export const config = {
+module.exports.config = {
   runtime: 'edge',
 };
 
-export default function handler(req) {
+module.exports.default = function handler(req) {
   const { searchParams } = new URL(req.url);
   const title = searchParams.get('title') || 'Digital Modenhet';
 


### PR DESCRIPTION
The `api/og.js` file was using ES module syntax (import/export) while your project's `package.json` specifies `"type": "commonjs"`. This mismatch can lead to build errors, especially in environments like Vercel Edge Functions.

This commit changes `api/og.js` to use CommonJS syntax (require/module.exports) to align with your project configuration and resolve potential build issues.