### PR TITLE
Improve separation between landing and form

### DIFF
--- a/evaluation.html
+++ b/evaluation.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="no">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Digital Modenhet Selvevaluering</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+    <!-- From original index.html -->
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <script>
+        window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
+    </script>
+    <script defer src="/_vercel/insights/script.js"></script>
+
+
+    <div class="container">
+        <h1>Selvevaluering - Digital Modenhet</h1>
+
+        <div id="intro-card" class="card">
+            <h2>Evaluer din organisasjons digitale modenhet</h2>
+            <p>Denne korte evalueringen vil hjelpe deg med å identifisere hvor din organisasjon befinner seg på skalaen for digital modenhet og dataeierskap. Du vil få tilbakemelding om nåværende nivå og anbefalinger for videre utvikling.</p>
+            <p>Evalueringen tar cirka 3 minutter å gjennomføre.</p>
+            <button id="start-btn" class="btn btn-primary">Start evalueringen</button>
+        </div>
+
+        <div id="question-container" class="card">
+            <div class="step-indicator">
+                <div class="step" id="step1"><div class="step-circle">1</div><div class="step-text">Datainnsamling</div></div>
+                <div class="step" id="step2"><div class="step-circle">2</div><div class="step-text">Dataanalyse</div></div>
+                <div class="step" id="step3"><div class="step-circle">3</div><div class="step-text">Dataprosesser</div></div>
+                <div class="step" id="step4"><div class="step-circle">4</div><div class="step-text">Strategi</div></div>
+                <div class="step" id="step5"><div class="step-circle">5</div><div class="step-text">Organisasjon</div></div>
+            </div>
+            <div class="progress-bar"><div class="progress" id="progress"></div></div>
+            <div id="questions-wrapper"></div>
+            <div class="navigation">
+                <button id="prev-btn" class="btn btn-secondary" disabled>Forrige</button>
+                <button id="next-btn" class="btn btn-primary" disabled>Neste</button>
+            </div>
+        </div>
+
+        <div id="result-container" class="card">
+            <div id="result-summary">
+                <div class="result-header-flex">
+                    <h3 id="result-level-combined">
+                        Resultat: Din bedrift er på <span id="level-number-actual" class="level-number-highlight"></span> "<span id="level-name-actual" class="level-name-normal"></span>"
+                    </h3>
+                    <div id="result-score-display" class="score-badge">
+                        <span id="score"></span><span id="max-score-display">/25</span> poeng
+                    </div>
+                </div>
+                <p id="result-description"></p>
+            </div>
+
+            <div class="visualization-group">
+                <h3>Visuell oversikt: Trappetrinnsmodell</h3>
+                <div id="canvas-container" aria-label="Visualisering av modenhetsnivå" aria-describedby="canvas-desc">
+                    <canvas id="result-canvas" width="800" height="320"></canvas>
+                    <div id="canvas-desc">
+                        Diagrammet viser din organisasjons nivå på en trappetrinnsmodell for digital modenhet.
+                    </div>
+                </div>
+            </div>
+
+            <div class="visualization-group">
+                <h3>Din modenhetsprofil per kategori</h3>
+                <div id="radar-chart-container" aria-label="Spindeldiagram som viser score per kategori" aria-describedby="radar-chart-desc">
+                    <canvas id="radar-chart" width="400" height="400"></canvas>
+                     <div id="radar-chart-desc">
+                        Spindeldiagrammet viser din score (1-5, eller gjennomsnitt hvis NA) for hver av de fem hovedkategoriene.
+                    </div>
+                </div>
+            </div>
+
+            <div id="maturity-profile-container" class="bg-white p-6 rounded-lg shadow-md mt-8" style="display: none;">
+                <h4 class="text-xl font-semibold mb-3 text-gray-700 flex items-center">
+                    <span class="section-icon-placeholder mr-2"></span> <!-- Placeholder for a potential icon -->
+                    Din Modenhetsprofil
+                </h4>
+                <div id="maturity-profile-content">
+                    <h5 id="maturity-profile-name" class="text-lg font-semibold text-blue-600 mb-1"></h5>
+                    <p id="maturity-profile-description" class="text-gray-600 mb-3"></p>
+                    <div class="mb-2">
+                        <strong class="text-gray-700">Typiske styrker:</strong>
+                        <ul id="maturity-profile-strengths" class="list-disc list-inside text-gray-600 pl-4"></ul>
+                    </div>
+                    <div>
+                        <strong class="text-gray-700">Typiske fallgruver:</strong>
+                        <ul id="maturity-profile-pitfalls" class="list-disc list-inside text-gray-600 pl-4"></ul>
+                    </div>
+                </div>
+            </div>
+
+            <div id="maturity-profile-feedback" class="mt-4 pt-4 border-t border-gray-200">
+                <h6 class="text-sm font-semibold text-gray-700 mb-2">Var denne profilbeskrivelsen treffende for din virksomhet?</h6>
+                <div class="flex items-center mb-2">
+                    <button id="feedback-yes-btn" type="button" class="bg-green-500 hover:bg-green-600 text-white text-sm font-medium px-4 py-2 rounded-md mr-2">Ja</button>
+                    <button id="feedback-no-btn" type="button" class="bg-red-500 hover:bg-red-600 text-white text-sm font-medium px-4 py-2 rounded-md mr-2">Nei</button>
+                </div>
+                <textarea id="feedback-comment" class="w-full p-2 border border-gray-300 rounded-md text-sm" rows="3" placeholder="Eventuelle kommentarer (valgfritt)..."></textarea>
+                <button id="submit-feedback-btn" type="button" class="mt-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium px-5 py-2 rounded-md">Send tilbakemelding</button>
+                <p id="feedback-confirmation-message" class="text-sm text-green-700 mt-2" style="display: none;">Takk for din tilbakemelding!</p>
+            </div>
+
+            <div class="details-toggle-section">
+                <button id="toggle-characteristics-btn" class="link-button" aria-expanded="false" aria-controls="level-details-content" style="display: none;">
+                    <span class="button-text-placeholder">Vis kjennetegn for nivået</span> <span class="icon-toggle">▼</span>
+                </button>
+                <div id="level-details-content" class="collapsible-content" hidden>
+                    <h4>Kjennetegn ved ditt nivå:</h4>
+                    <ul id="level-characteristics"></ul>
+                </div>
+            </div>
+
+            <div id="gaps-container" class="gaps">
+                <h4 id="gaps-title"><span class="section-icon-placeholder"></span>Dine forbedringsområder</h4>
+                <div id="gaps-list"></div>
+            </div>
+
+            <div id="recommendations-container" class="recommendations-section" style="display: none;">
+                <h4><span class="section-icon-placeholder"></span>Anbefalte neste steg</h4>
+                <div id="recommendations-list-structured"></div>
+            </div>
+
+            <div class="restart-container">
+                <button id="restart-btn" class="btn btn-secondary">Start på nytt</button>
+            </div>
+        </div>
+
+        <div id="action-plan-container" class="bg-white p-6 rounded-lg shadow-md mt-8" style="display: none;">
+            <h4 class="text-xl font-semibold mb-3 text-gray-700 flex items-center">
+                <span class="section-icon-placeholder mr-2"></span> <!-- Placeholder for a potential icon -->
+                Min Handlingsplan
+            </h4>
+            <div id="action-plan-list" class="space-y-2">
+                <!-- Selected recommendations will be dynamically added here -->
+                <p id="action-plan-empty-message" class="text-gray-500 italic">Du har ikke valgt noen anbefalinger til handlingsplanen din ennå. Klikk på stjerneikonet ved siden av en anbefaling for å legge den til.</p>
+            </div>
+        </div>
+    </div>
+
+    <script src="script.js"></script>
+    <!-- From original index.html -->
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <script>
+      lucide.createIcons();
+      AOS.init({ once: true });
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -12,143 +12,41 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/lucide@latest"></script>
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
-    <!-- From index2.html -->
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <script>
         window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments); };
     </script>
-    <script defer src="/_vercel/insights/script.js"></script>
-    <div class="container">
-        <h1>Selvevaluering - Digital Modenhet</h1>
 
-        <div id="intro-card" class="card">
-            <h2>Evaluer din organisasjons digitale modenhet</h2>
-            <p>Denne korte evalueringen vil hjelpe deg med å identifisere hvor din organisasjon befinner seg på skalaen for digital modenhet og dataeierskap. Du vil få tilbakemelding om nåværende nivå og anbefalinger for videre utvikling.</p>
-            <p>Evalueringen tar cirka 3 minutter å gjennomføre.</p>
-            <button id="start-btn" class="btn btn-primary">Start evalueringen</button>
-        </div>
+    <header class="hero">
+        <h1>Digital Modenhet</h1>
+        <p>Få et raskt overblikk over hvor digitalt moden virksomheten din er.</p>
+        <a href="evaluation.html" class="btn btn-primary hero-btn">Kom i gang</a>
+    </header>
 
-        <div id="question-container" class="card">
-            <div class="step-indicator">
-                <div class="step" id="step1"><div class="step-circle">1</div><div class="step-text">Datainnsamling</div></div>
-                <div class="step" id="step2"><div class="step-circle">2</div><div class="step-text">Dataanalyse</div></div>
-                <div class="step" id="step3"><div class="step-circle">3</div><div class="step-text">Dataprosesser</div></div>
-                <div class="step" id="step4"><div class="step-circle">4</div><div class="step-text">Strategi</div></div>
-                <div class="step" id="step5"><div class="step-circle">5</div><div class="step-text">Organisasjon</div></div>
+    <section class="features">
+        <h2>Hvorfor ta testen?</h2>
+        <div class="feature-grid">
+            <div class="feature-card">
+                <i data-lucide="zap" aria-hidden="true"></i>
+                <h3>Raskt</h3>
+                <p>Kun noen få minutters innsats.</p>
             </div>
-            <div class="progress-bar"><div class="progress" id="progress"></div></div>
-            <div id="questions-wrapper"></div>
-            <div class="navigation">
-                <button id="prev-btn" class="btn btn-secondary" disabled>Forrige</button>
-                <button id="next-btn" class="btn btn-primary" disabled>Neste</button>
+            <div class="feature-card">
+                <i data-lucide="eye" aria-hidden="true"></i>
+                <h3>Innsiktsfullt</h3>
+                <p>Identifiser styrker og forbedringsområder.</p>
             </div>
-        </div>
-
-        <div id="result-container" class="card">
-            <div id="result-summary">
-                <div class="result-header-flex">
-                    <h3 id="result-level-combined">
-                        Resultat: Din bedrift er på <span id="level-number-actual" class="level-number-highlight"></span> "<span id="level-name-actual" class="level-name-normal"></span>"
-                    </h3>
-                    <div id="result-score-display" class="score-badge">
-                        <span id="score"></span><span id="max-score-display">/25</span> poeng
-                    </div>
-                </div>
-                <p id="result-description"></p>
-            </div>
-
-            <div class="visualization-group">
-                <h3>Visuell oversikt: Trappetrinnsmodell</h3>
-                <div id="canvas-container" aria-label="Visualisering av modenhetsnivå" aria-describedby="canvas-desc">
-                    <canvas id="result-canvas" width="800" height="320"></canvas>
-                    <div id="canvas-desc">
-                        Diagrammet viser din organisasjons nivå på en trappetrinnsmodell for digital modenhet.
-                    </div>
-                </div>
-            </div>
-
-            <div class="visualization-group">
-                <h3>Din modenhetsprofil per kategori</h3>
-                <div id="radar-chart-container" aria-label="Spindeldiagram som viser score per kategori" aria-describedby="radar-chart-desc">
-                    <canvas id="radar-chart" width="400" height="400"></canvas>
-                     <div id="radar-chart-desc">
-                        Spindeldiagrammet viser din score (1-5, eller gjennomsnitt hvis NA) for hver av de fem hovedkategoriene.
-                    </div>
-                </div>
-            </div>
-
-            <div id="maturity-profile-container" class="bg-white p-6 rounded-lg shadow-md mt-8" style="display: none;">
-                <h4 class="text-xl font-semibold mb-3 text-gray-700 flex items-center">
-                    <span class="section-icon-placeholder mr-2"></span> <!-- Placeholder for a potential icon -->
-                    Din Modenhetsprofil
-                </h4>
-                <div id="maturity-profile-content">
-                    <h5 id="maturity-profile-name" class="text-lg font-semibold text-blue-600 mb-1"></h5>
-                    <p id="maturity-profile-description" class="text-gray-600 mb-3"></p>
-                    <div class="mb-2">
-                        <strong class="text-gray-700">Typiske styrker:</strong>
-                        <ul id="maturity-profile-strengths" class="list-disc list-inside text-gray-600 pl-4"></ul>
-                    </div>
-                    <div>
-                        <strong class="text-gray-700">Typiske fallgruver:</strong>
-                        <ul id="maturity-profile-pitfalls" class="list-disc list-inside text-gray-600 pl-4"></ul>
-                    </div>
-                </div>
-            </div>
-
-            <div id="maturity-profile-feedback" class="mt-4 pt-4 border-t border-gray-200">
-                <h6 class="text-sm font-semibold text-gray-700 mb-2">Var denne profilbeskrivelsen treffende for din virksomhet?</h6>
-                <div class="flex items-center mb-2">
-                    <button id="feedback-yes-btn" type="button" class="bg-green-500 hover:bg-green-600 text-white text-sm font-medium px-4 py-2 rounded-md mr-2">Ja</button>
-                    <button id="feedback-no-btn" type="button" class="bg-red-500 hover:bg-red-600 text-white text-sm font-medium px-4 py-2 rounded-md mr-2">Nei</button>
-                </div>
-                <textarea id="feedback-comment" class="w-full p-2 border border-gray-300 rounded-md text-sm" rows="3" placeholder="Eventuelle kommentarer (valgfritt)..."></textarea>
-                <button id="submit-feedback-btn" type="button" class="mt-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium px-5 py-2 rounded-md">Send tilbakemelding</button>
-                <p id="feedback-confirmation-message" class="text-sm text-green-700 mt-2" style="display: none;">Takk for din tilbakemelding!</p>
-            </div>
-
-            <div class="details-toggle-section">
-                <button id="toggle-characteristics-btn" class="link-button" aria-expanded="false" aria-controls="level-details-content" style="display: none;">
-                    <span class="button-text-placeholder">Vis kjennetegn for nivået</span> <span class="icon-toggle">▼</span>
-                </button>
-                <div id="level-details-content" class="collapsible-content" hidden>
-                    <h4>Kjennetegn ved ditt nivå:</h4>
-                    <ul id="level-characteristics"></ul>
-                </div>
-            </div>
-
-            <div id="gaps-container" class="gaps">
-                <h4 id="gaps-title"><span class="section-icon-placeholder"></span>Dine forbedringsområder</h4>
-                <div id="gaps-list"></div>
-            </div>
-
-            <div id="recommendations-container" class="recommendations-section" style="display: none;">
-                <h4><span class="section-icon-placeholder"></span>Anbefalte neste steg</h4>
-                <div id="recommendations-list-structured"></div>
-            </div>
-
-            <div class="restart-container">
-                <button id="restart-btn" class="btn btn-secondary">Start på nytt</button>
+            <div class="feature-card">
+                <i data-lucide="gift" aria-hidden="true"></i>
+                <h3>Kostnadsfritt</h3>
+                <p>Verktøyet er helt gratis.</p>
             </div>
         </div>
+    </section>
 
-        <div id="action-plan-container" class="bg-white p-6 rounded-lg shadow-md mt-8" style="display: none;">
-            <h4 class="text-xl font-semibold mb-3 text-gray-700 flex items-center">
-                <span class="section-icon-placeholder mr-2"></span> <!-- Placeholder for a potential icon -->
-                Min Handlingsplan
-            </h4>
-            <div id="action-plan-list" class="space-y-2">
-                <!-- Selected recommendations will be dynamically added here -->
-                <p id="action-plan-empty-message" class="text-gray-500 italic">Du har ikke valgt noen anbefalinger til handlingsplanen din ennå. Klikk på stjerneikonet ved siden av en anbefaling for å legge den til.</p>
-            </div>
-        </div>
-    </div>
 
-    <!-- From index2.html -->
-    <script src="script.js"></script>
     <!-- From original index.html -->
     <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <script>

--- a/server.js
+++ b/server.js
@@ -96,7 +96,7 @@ const staticBasePath = path.resolve(__dirname);
 
 function serveStatic(res, pathname) {
   if (pathname === '/' || pathname === '') {
-    pathname = '/index2.html';
+    pathname = '/index.html';
   }
 
   const filePath = path.resolve(path.join(staticBasePath, pathname));

--- a/style.css
+++ b/style.css
@@ -39,6 +39,69 @@
             padding: 20px;
             transition: all 0.3s ease;
         }
+        .hero {
+            text-align: center;
+            padding: 60px 20px;
+        }
+        .hero h1 {
+            font-size: 2.5rem;
+            color: var(--text-color-dark);
+            margin-bottom: 15px;
+        }
+        .hero p {
+            font-size: 1.2rem;
+            color: var(--text-color-medium);
+            margin-bottom: 25px;
+        }
+        .hero-btn {
+            font-size: 1.1rem;
+            padding: 12px 20px;
+        }
+        .features {
+            max-width: 900px;
+            margin: 0 auto 40px;
+        }
+        .features h2 {
+            text-align: center;
+            color: var(--text-color-dark);
+            margin-bottom: 20px;
+        }
+        .feature-grid {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: 20px;
+        }
+        .feature-card {
+            background-color: var(--background-color-card);
+            border: 1px solid var(--border-color-light);
+            border-radius: 8px;
+            padding: 20px;
+            flex: 1 1 240px;
+            max-width: 260px;
+            text-align: center;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        .feature-card:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 6px 10px rgba(0, 0, 0, 0.1);
+        }
+        .feature-card i {
+            width: 32px;
+            height: 32px;
+            color: var(--primary-color);
+            margin-bottom: 10px;
+        }
+        .feature-card h3 {
+            font-size: 1.25rem;
+            margin-bottom: 6px;
+            color: var(--text-color-dark);
+        }
+        .feature-card p {
+            font-size: 0.95rem;
+            color: var(--text-color-medium);
+        }
         .card:hover {
             transform: translateY(-4px);
             box-shadow: 0 6px 10px rgba(0, 0, 0, 0.1);
@@ -448,7 +511,14 @@
             .card { padding: 15px; }
             .step-text { font-size: 10px; max-width: 70px; }
             .question { font-size: 16px; }
-            
+
+            .hero { padding: 40px 15px; }
+            .hero h1 { font-size: 2rem; }
+            .hero p { font-size: 1rem; }
+            .hero-btn { font-size: 1rem; padding: 10px 16px; }
+            .features { margin-bottom: 30px; }
+            .feature-card { flex: 1 1 100%; max-width: none; }
+
             .result-header-flex { flex-direction: column; align-items: stretch; gap: 10px; }
             h3#result-level-combined { font-size: 1.3em; text-align: center; }
             .score-badge { font-size: 1em; padding: 6px 12px; align-self: center; }


### PR DESCRIPTION
## Summary
- keep dedicated evaluation page
- style landing page with hero section
- showcase feature cards with icons
- link hero CTA directly to form

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_684c365a7b748322a80834e84af47beb